### PR TITLE
Changed CommandGroup to throw CommandNotFoundException

### DIFF
--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -70,12 +70,20 @@ namespace DSharpPlus.CommandsNext
             }
 
             if (!this.IsExecutableWithoutSubcommands)
+            {
+                string exMsg;
+                if (cn == null)
+                    exMsg = base.Name;
+                else
+                    exMsg = base.Name + " " + cn;
                 return new CommandResult
                 {
                     IsSuccessful = false,
-                    Exception = new InvalidOperationException("No matching subcommands were found, and this group is not executable."),
+                    Exception = new CommandNotFoundException(exMsg),
                     Context = ctx
                 };
+            }
+                
 
             return await base.ExecuteAsync(ctx).ConfigureAwait(false);
         }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -152,11 +152,11 @@ namespace DSharpPlus.Test
             return Task.CompletedTask;
         }
 
-        //private Task Discord_ClientErrored(DiscordClient client, ClientErrorEventArgs e)
-        //{
-        //    e.Client.Logger.LogError(TestBotEventId, e.Exception, "Client threw an exception");
-        //    return Task.CompletedTask;
-        //}
+        /*private Task Discord_ClientErrored(DiscordClient client, ClientErrorEventArgs e)
+        {
+            client.Logger.LogError(TestBotEventId, e.Exception, "Client threw an exception");
+            return Task.CompletedTask;
+        }*/
 
         private Task Discord_SocketError(DiscordClient client, SocketErrorEventArgs e)
         {
@@ -180,7 +180,17 @@ namespace DSharpPlus.Test
         private async Task CommandsNextService_CommandErrored(CommandsNextExtension cnext, CommandErrorEventArgs e)
         {
             if (e.Exception is CommandNotFoundException && (e.Command == null || e.Command.QualifiedName != "help"))
+            {
+                var embed = new DiscordEmbedBuilder
+                {
+                    Color = new DiscordColor("#FF0000"),
+                    Title = "Command Not Found Exception",
+                    Description = $"`{((CommandNotFoundException)e.Exception).CommandName}`, no such command or subcommand was found.",
+                    Timestamp = DateTime.UtcNow
+                };
+                await e.Context.RespondAsync("", embed: embed);
                 return;
+            }
 
             e.Context.Client.Logger.LogError(TestBotEventId, e.Exception, "Exception occurred during {0}'s invocation of '{1}'", e.Context.User.Username, e.Context.Command.QualifiedName);
 

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -181,6 +181,7 @@ namespace DSharpPlus.Test
         {
             if (e.Exception is CommandNotFoundException && (e.Command == null || e.Command.QualifiedName != "help"))
             {
+                // Not logged as error to console because it's an user caused error
                 var embed = new DiscordEmbedBuilder
                 {
                     Color = new DiscordColor("#FF0000"),


### PR DESCRIPTION
Small modification to TestBot's command error handling to allow testing of the exception change.

# Summary
- CommandGroup ExecuteAsync now throws a CommandNotFoundException instead of an InvalidOperationException if no matching subcommands were found and the group is not executable
- Modified TestBot's CommandErrored handler to inform of a CommandNotFoundException