### PR TITLE
Fix message-related exceptions in threads

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1,4 +1,4 @@
-// This file is part of the DSharpPlus project.
+t// This file is part of the DSharpPlus project.
 //
 // Copyright (c) 2015 Mike Santiago
 // Copyright (c) 2016-2021 DSharpPlus Contributors
@@ -251,7 +251,13 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(string content)
         {
-            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+            return this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News
                 ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
                 : this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
@@ -267,7 +273,13 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed)
         {
-            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+            return this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News
                 ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
                 : this.Discord.ApiClient.CreateMessageAsync(this.Id, null, new[] {embed}, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
@@ -284,7 +296,13 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed)
         {
-            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+            return this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News
                 ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
                 : this.Discord.ApiClient.CreateMessageAsync(this.Id, content, new[] {embed}, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
@@ -488,7 +506,13 @@ namespace DSharpPlus.Entities
 
         private async Task<IReadOnlyList<DiscordMessage>> GetMessagesInternalAsync(int limit = 100, ulong? before = null, ulong? after = null, ulong? around = null)
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
+            if (this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot get the messages of a non-text channel.");
 
             if (limit < 0)
@@ -667,7 +691,13 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task TriggerTypingAsync()
         {
-            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News && this.Type != ChannelType.PublicThread && this.Type != ChannelType.PrivateThread && this.Type != ChannelType.NewsThread
+            return this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News
                 ? throw new ArgumentException("Cannot start typing in a non-text channel.")
                 : this.Discord.ApiClient.TriggerTypingAsync(this.Id);
         }
@@ -682,7 +712,13 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync()
         {
-            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+            return this.Type != ChannelType.Text &&
+                this.Type != ChannelType.PublicThread &&
+                this.Type != ChannelType.PrivateThread &&
+                this.Type != ChannelType.NewsThread &&
+                this.Type != ChannelType.Private &&
+                this.Type != ChannelType.Group &&
+                this.Type != ChannelType.News
                 ? throw new ArgumentException("A non-text channel does not have pinned messages.")
                 : this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
         }

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1,4 +1,4 @@
-t// This file is part of the DSharpPlus project.
+// This file is part of the DSharpPlus project.
 //
 // Copyright (c) 2015 Mike Santiago
 // Copyright (c) 2016-2021 DSharpPlus Contributors


### PR DESCRIPTION
# Summary
Fixes exceptions thrown when trying to run message-related functions when the channel is a thread..

# Changes proposed
Added the thread channel check to the previous checks so thread channels are allowed to send messages.